### PR TITLE
feat: Implement real multi-process Nmap runner and UI controls

### DIFF
--- a/nextgen/backend/.dockerignore
+++ b/nextgen/backend/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+.env
+.venv/
+build/
+dist/
+Dockerfile

--- a/nextgen/backend/Dockerfile
+++ b/nextgen/backend/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.12-slim AS base
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+WORKDIR /app
+
+# Install nmap and deps
+RUN apt-get update && apt-get install -y --no-install-recommends nmap ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+# ---------- Development ----------
+FROM base AS dev
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--reload", "--host", "0.0.0.0", "--port", "8000"]
+
+# ---------- Production ----------
+FROM base AS prod
+RUN pip install --no-cache-dir "gunicorn>=21.2"
+EXPOSE 8000
+CMD ["gunicorn", "-k", "uvicorn.workers.UvicornWorker", "-w", "2", "-b", "0.0.0.0:8000", "main:app"]

--- a/nextgen/backend/nmap_runner.py
+++ b/nextgen/backend/nmap_runner.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+import asyncio
+import os
+import shlex
+import signal
+import time
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Tuple
+import contextlib
+
+EventCb = Callable[[str, Dict], asyncio.Future | None]
+
+def now_ms() -> int:
+    return int(time.time() * 1000)
+
+class NmapRunner:
+    def __init__(self, state_dir: str = "/app/data", nmap_path: str = "nmap", event_cb: Optional[EventCb] = None):
+        self.state_dir = Path(state_dir)
+        self.scans_dir = self.state_dir / "scans"
+        self.scans_dir.mkdir(parents=True, exist_ok=True)
+        self.nmap_path = nmap_path
+        self.event_cb = event_cb or (lambda *_args, **_kwargs: None)
+        self._abort: Dict[str, asyncio.Event] = {}
+        self._procs: Dict[str, List[asyncio.subprocess.Process]] = {}
+
+    def _get_abort(self, chunk_id: str) -> asyncio.Event:
+        ev = self._abort.get(chunk_id)
+        if not ev:
+            ev = asyncio.Event()
+            self._abort[chunk_id] = ev
+        return ev
+
+    async def abort_chunk(self, chunk_id: str):
+        # Signal abort and attempt to terminate any tracked procs
+        ev = self._get_abort(chunk_id)
+        ev.set()
+        for proc in self._procs.get(chunk_id, []):
+            if proc.returncode is None:
+                try:
+                    proc.send_signal(signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+        # Give them a moment, then SIGKILL any stragglers
+        await asyncio.sleep(1.0)
+        for proc in self._procs.get(chunk_id, []):
+            if proc.returncode is None:
+                try:
+                    proc.kill()
+                except ProcessLookupError:
+                    pass
+
+    async def _emit(self, typ: str, **payload):
+        coro = self.event_cb(typ, payload)
+        if asyncio.iscoroutine(coro):
+            await coro
+
+    def _build_cmd(self, ip: str, settings: Dict) -> List[str]:
+        host_timeout = int(settings.get("host_timeout_sec", 60))
+        profile = settings.get("profile", "balanced")
+        scan_type = settings.get("scan_type", "sT")  # sS needs NET_RAW caps; sT is safe
+        ports = settings.get("ports", "top-1000")
+        extra_args = settings.get("extra_args", "").strip()
+
+        cmd = [self.nmap_path, "-Pn", "-n", f"-{scan_type}", "--host-timeout", f"{host_timeout}s", "-oX", "-"]
+        # timing presets
+        if profile == "fast":
+            cmd += ["-T4", "--max-retries", "1"]
+        elif profile == "thorough":
+            cmd += ["-T3", "--max-retries", "2"]
+        else:
+            cmd += ["-T4", "--max-retries", "1"]
+
+        # ports handling
+        if isinstance(ports, str) and ports.startswith("top-"):
+            topn = ports.split("-", 1)[1]
+            if topn.isdigit():
+                cmd += ["--top-ports", topn]
+        elif ports:
+            cmd += ["-p", str(ports)]
+
+        # any extra args
+        if extra_args:
+            cmd += shlex.split(extra_args)
+
+        cmd += [ip]
+        return cmd
+
+    async def _scan_ip(self, chunk_id: str, ip: str, settings: Dict, abort_event: asyncio.Event) -> Tuple[str, bool, int]:
+        started = time.time()
+        cmd = self._build_cmd(ip, settings)
+        out_dir = self.scans_dir / chunk_id
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_xml = out_dir / f"{ip}.xml"
+
+        proc = await asyncio.create_subprocess_exec(*cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+        self._procs.setdefault(chunk_id, []).append(proc)
+
+        try:
+            # Outer watchdog in case host_timeout is ignored
+            host_timeout = int(settings.get("host_timeout_sec", 60))
+            try:
+                stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=host_timeout + 15)
+            except asyncio.TimeoutError:
+                # External kill if nmap didn't respect host-timeout
+                with contextlib.suppress(ProcessLookupError):
+                    proc.send_signal(signal.SIGTERM)
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=3)
+                except asyncio.TimeoutError:
+                    with contextlib.suppress(ProcessLookupError):
+                        proc.kill()
+                stdout = stdout if 'stdout' in locals() else b""
+                stderr = b"timeout"
+
+            # Write XML (may be empty on failure)
+            try:
+                out_xml.write_bytes(stdout or b"")
+            except Exception:
+                pass
+
+            ok = (proc.returncode == 0) and bool(stdout)
+            await self._emit("host_completed", chunk_id=chunk_id, ip=ip, ok=ok, duration_ms=int((time.time() - started) * 1000))
+            return ip, ok, int((time.time() - started) * 1000)
+
+        finally:
+            # Check abort
+            if abort_event.is_set() and proc.returncode is None:
+                with contextlib.suppress(ProcessLookupError):
+                    proc.kill()
+
+    async def scan_chunk(self, chunk_id: str, targets: List[str], settings: Dict):
+        abort_event = self._get_abort(chunk_id)
+        per_host_workers = int(settings.get("per_host_workers", 8))
+        sem = asyncio.Semaphore(per_host_workers)
+
+        completed = 0
+        total = len(targets)
+        failed_hosts: List[str] = []
+
+        async def worker(ip: str):
+            nonlocal completed
+            async with sem:
+                if abort_event.is_set():
+                    return
+                _, ok, _ = await self._scan_ip(chunk_id, ip, settings, abort_event)
+                completed += 1
+                if not ok:
+                    failed_hosts.append(ip)
+                await self._emit(
+                    "chunk_progress",
+                    chunk_id=chunk_id,
+                    completed_hosts=completed,
+                    total_hosts=total,
+                    elapsed_ms=0,
+                    last_heartbeat_ms=0,
+                )
+
+        await asyncio.gather(*[worker(ip) for ip in targets if not abort_event.is_set()])
+        # Cleanup tracking
+        self._procs.pop(chunk_id, None)
+        # Completion event is emitted by caller after status update
+        return {"completed": completed, "failed": failed_hosts}

--- a/nextgen/backend/requirements.txt
+++ b/nextgen/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn[standard]
+pydantic

--- a/nextgen/docker-compose.yml
+++ b/nextgen/docker-compose.yml
@@ -1,0 +1,66 @@
+version: "3.9"
+
+volumes:
+  sqlite_data:
+
+services:
+  api:
+    build:
+      context: ./backend
+      target: dev
+    environment:
+      - STATE_DIR=/app/data
+    volumes:
+      - ./backend:/app
+      - sqlite_data:/app/data
+    ports:
+      - "8000:8000"
+    # Allow SYN scan with -sS inside container; otherwise use -sT
+    cap_add:
+      - NET_RAW
+      - NET_ADMIN
+    profiles: ["dev"]
+
+  web:
+    build:
+      context: ./frontend
+      target: dev
+    environment:
+      - PUBLIC_API_BASE=http://api:8000
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    ports:
+      - "5173:5173"
+    depends_on:
+      - api
+    profiles: ["dev"]
+
+  api-prod:
+    build:
+      context: ./backend
+      target: prod
+    environment:
+      - STATE_DIR=/app/data
+    volumes:
+      - sqlite_data:/app/data
+    ports:
+      - "8000:8000"
+    cap_add:
+      - NET_RAW
+      - NET_ADMIN
+    profiles: ["prod"]
+
+  web-prod:
+    build:
+      context: ./frontend
+      target: prod
+      args:
+        PUBLIC_API_BASE: http://api-prod:8000
+    environment:
+      - PUBLIC_API_BASE=http://api-prod:8000
+    ports:
+      - "8080:4173"
+    depends_on:
+      - api-prod
+    profiles: ["prod"]

--- a/nextgen/frontend/.dockerignore
+++ b/nextgen/frontend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules/
+.svelte-kit/
+build/
+dist/
+.env
+Dockerfile

--- a/nextgen/frontend/src/routes/+page.svelte
+++ b/nextgen/frontend/src/routes/+page.svelte
@@ -9,6 +9,10 @@
   let maxWorkers = 4;
   let parts = 2;
   let loading = false;
+  let perHostWorkers = 8;
+  let scanType = 'sT'; // sS if container has NET_RAW
+  let ports = 'top-1000';
+  let extraArgs = '';
   let error = '';
 
   async function refresh() {
@@ -36,6 +40,16 @@
 
   async function setWorkers() {
     try { await updateSettings({ max_workers: maxWorkers }); } finally {}
+  }
+
+  async function applyScanSettings() {
+    await updateSettings({
+      max_workers: maxWorkers,
+      per_host_workers: perHostWorkers,
+      scan_type: scanType,
+      ports,
+      extra_args: extraArgs
+    });
   }
 
   async function doKill(id: string) { await killChunk(id); }
@@ -74,6 +88,25 @@
       <input class="ml-2 border rounded p-1 w-20" type="number" min="2" bind:value={parts} />
     </label>
     <button class="px-3 py-1 border rounded" on:click={refresh} disabled={loading}>{loading ? 'Refreshing...' : 'Refresh'}</button>
+  </div>
+  <div class="flex flex-wrap items-end gap-3">
+    <!-- existing controls -->
+    <label class="text-sm">Per-host workers
+      <input class="ml-2 border rounded p-1 w-20" type="number" min="1" bind:value={perHostWorkers} />
+    </label>
+    <label class="text-sm">Scan type
+      <select class="ml-2 border rounded p-1" bind:value={scanType}>
+        <option value="sT">-sT (TCP Connect)</option>
+        <option value="sS">-sS (SYN, needs NET_RAW)</option>
+      </select>
+    </label>
+    <label class="text-sm">Ports
+      <input class="ml-2 border rounded p-1 w-48" placeholder="top-1000 or 1-1024,3389" bind:value={ports} />
+    </label>
+    <label class="text-sm">Extra args
+      <input class="ml-2 border rounded p-1 w-64" placeholder="--min-rate 1000" bind:value={extraArgs} />
+    </label>
+    <button class="px-3 py-1 border rounded bg-indigo-600 text-white" on:click={applyScanSettings}>Apply scan settings</button>
   </div>
 </section>
 


### PR DESCRIPTION
This commit replaces the fake scanning engine with a real, concurrent Nmap runner and integrates it into the FastAPI backend and SvelteKit frontend.

Key changes:
- Adds `nmap_runner.py` to execute and manage parallel Nmap processes for hosts within a chunk. It supports cancellation, per-host timeouts, and writes XML output.
- Replaces the backend's mock runner loop in `main.py` with a task-based scheduler that uses the new `NmapRunner`.
- Extends the `Settings` model and the UI to allow operator control over scan parameters like scan type (-sS, -sT), ports, per-host workers, and extra Nmap arguments.
- Introduces `Dockerfile` for the backend that installs Nmap.
- Adds a `docker-compose.yml` for development and production, which provides the necessary `NET_RAW`/`NET_ADMIN` capabilities for SYN scanning and mounts a persistent volume for scan data.