### PR TITLE
feat: add endpoint for one-off nmap scans

### DIFF
--- a/nextgen/README.md
+++ b/nextgen/README.md
@@ -28,6 +28,15 @@ This project contains a real-time "Nmap Parallel Scanner" control panel.
     ```
     The backend will be running at `http://localhost:8000`.
 
+    A one-off scan can be triggered via:
+
+    ```sh
+    curl -X POST http://localhost:8000/nmap/run \
+      -H 'Content-Type: application/json' \
+      -d '{"target": "scanme.nmap.org"}'
+    ```
+    The response includes the executed command and parsed scan results.
+
 ### Frontend
 
 1.  Navigate to the frontend directory:

--- a/nextgen/backend/nmap_runner.py
+++ b/nextgen/backend/nmap_runner.py
@@ -85,6 +85,22 @@ class NmapRunner:
         cmd += [ip]
         return cmd
 
+    def build_cmd(self, ip: str, settings: Dict) -> List[str]:
+        """Public helper to build the nmap command for an IP."""
+        return self._build_cmd(ip, settings)
+
+    async def run_command(self, ip: str, settings: Dict) -> Tuple[List[str], int, str, str]:
+        """
+        Build and execute an nmap command immediately for the given IP.
+        Returns the command list, return code, stdout and stderr (decoded).
+        """
+        cmd = self._build_cmd(ip, settings)
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        )
+        stdout, stderr = await proc.communicate()
+        return cmd, proc.returncode, stdout.decode(), stderr.decode()
+
     async def _scan_ip(self, chunk_id: str, ip: str, settings: Dict, abort_event: asyncio.Event) -> Tuple[str, bool, int]:
         started = time.time()
         cmd = self._build_cmd(ip, settings)


### PR DESCRIPTION
## Summary
- expose helper methods in NmapRunner to build and execute custom nmap commands
- add `/nmap/run` API endpoint that runs a single-host scan and returns parsed results
- document one-off scan usage in nextgen README

## Testing
- `pytest` *(fails: nmap program was not found in path)*
- `python -m py_compile nextgen/backend/main.py nextgen/backend/nmap_runner.py`


------
https://chatgpt.com/codex/tasks/task_b_689d6031b7f8832189f4cdcf1ae11063