### PR TITLE
Add chunk selection and command-line logging for scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ python nmap_parallel_scanner.py [OPTIONS]
     -   Number of IPs per chunk for parallel scanning.
     -   Default: `10`.
 
+-   `--select-chunks` (optional)
+    -   After displaying the list of chunks, prompt to choose specific chunk numbers to scan.
+    -   Press Enter to scan all chunks.
+
 -   `--num-processes NUM_PROCESSES` (optional)
     -   Number of parallel Nmap processes.
     -   Default: Number of CPU cores on your system.

--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -15,21 +15,41 @@ def run_nmap_scan(targets: List[str], options: str = "-T4 -F") -> Dict[str, Any]
         A dictionary containing the parsed Nmap scan results (or error details)
         and the original list of input_targets.
     """
-    nm = nmap.PortScanner()
     target_string = " ".join(targets)
     # Initialize result_dict with input_targets. This ensures it's always present.
     result_dict: Dict[str, Any] = {"input_targets": targets}
 
+    # Build the command string up-front so it is available even if execution fails
+    command = f"nmap -oX - {options} {target_string}"
+    result_dict["command"] = command
+
+    try:
+        nm = nmap.PortScanner()
+    except nmap.PortScannerError as e:
+        error_msg = f"Nmap initialization failed for targets '{target_string}': {str(e)}"
+        logging.error(error_msg)
+        result_dict["error"] = "Nmap execution failed."
+        if "nmap program was not found" in str(e).lower():
+            result_dict["details"] = "Nmap command not found. Please ensure Nmap is installed and in your system's PATH."
+        else:
+            result_dict["details"] = str(e)
+        return result_dict
+
     try:
         # Construct the command string for logging, mimicking python-nmap's behavior.
         # python-nmap adds '-oX -' to parse the output.
-        command = f"nmap -oX - {options} {target_string}"
         logging.debug(f"Attempting to run Nmap command: {command}")
 
         # The scan method of python-nmap executes nmap and parses XML output.
         scan_output = nm.scan(hosts=target_string, arguments=options)
-        logging.debug(f"Nmap command finished successfully. Full command executed: '{nm.command_line()}'")
+        executed_cmd = nm.command_line()
+        result_dict["command_line"] = executed_cmd
+        logging.debug(f"Nmap command finished successfully. Full command executed: '{executed_cmd}'")
 
+        try:
+            result_dict["nmap_output"] = nm.get_nmap_last_output()
+        except Exception:
+            pass
 
         # Merge the raw scan_output into our result_dict.
         # scan_output structure is typically {'nmap': {...}, 'scan': {host1:..., host2:...}}
@@ -46,9 +66,9 @@ def run_nmap_scan(targets: List[str], options: str = "-T4 -F") -> Dict[str, Any]
 
             if current_scan_stats.get('uphosts', '0') == '0' and \
                current_scan_stats.get('totalhosts', '0') != '0': # Check if scan ran and all were down
-                 result_dict["status"] = "completed"
-                 result_dict["message"] = f"All {current_scan_stats.get('totalhosts','')} specified target(s) are down or did not respond."
-                 # result_dict["hosts_scanned"] = nm.all_hosts() # This would be empty
+                result_dict["status"] = "completed"
+                result_dict["message"] = f"All {current_scan_stats.get('totalhosts','')} specified target(s) are down or did not respond."
+                # result_dict["hosts_scanned"] = nm.all_hosts() # This would be empty
             else:
                 # If 'scan' is empty but not because all hosts are down (e.g. bad options, other nmap issue)
                 # and no specific error message has been set yet by an exception.
@@ -61,12 +81,10 @@ def run_nmap_scan(targets: List[str], options: str = "-T4 -F") -> Dict[str, Any]
                     )
 
     except nmap.PortScannerError as e:
-        # This exception is raised if Nmap is not found or if there's an error running the command
-        # (e.g., malformed arguments that nmap itself rejects).
+        # This exception is raised if Nmap encounters an error during execution
         error_msg = f"Nmap scan error for targets '{target_string}': {str(e)}"
         logging.error(error_msg)
         result_dict["error"] = "Nmap execution failed."
-        # Provide a more specific detail if Nmap is not found.
         if "nmap program was not found" in str(e).lower():
             result_dict["details"] = "Nmap command not found. Please ensure Nmap is installed and in your system's PATH."
         elif "Error compiling our pcap filter" in str(e):
@@ -78,9 +96,12 @@ def run_nmap_scan(targets: List[str], options: str = "-T4 -F") -> Dict[str, Any]
             )
         else:
             result_dict["details"] = str(e)
-        # Include scan stats if available even in error, though might be minimal
         if nm.scanstats():
-             result_dict["stats"] = nm.scanstats()
+            result_dict["stats"] = nm.scanstats()
+        try:
+            result_dict["nmap_output"] = nm.get_nmap_last_output()
+        except Exception:
+            pass
 
     except Exception as e:
         # Catch any other unexpected errors during the scan process.
@@ -89,6 +110,10 @@ def run_nmap_scan(targets: List[str], options: str = "-T4 -F") -> Dict[str, Any]
         result_dict["error"] = "Unexpected error during scan."
         result_dict["details"] = str(e)
         if nm.scanstats(): # Try to get stats
-             result_dict["stats"] = nm.scanstats()
+            result_dict["stats"] = nm.scanstats()
+        try:
+            result_dict["nmap_output"] = nm.get_nmap_last_output()
+        except Exception:
+            pass
 
     return result_dict


### PR DESCRIPTION
## Summary
- display chunk table with optional interactive selection
- log exact nmap command, raw output, and errors per chunk
- document `--select-chunks` usage

## Testing
- `python nmap_parallel_scanner.py -i data/sample_inputs/ips.txt -o ./tmp/scan_results2 --num-processes 1 --nmap-options "-sT -vvv -F --open --unprivileged" --chunk-size 1`
- `pytest` *(fails: Nmap command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689dba7264d483218fe0b6dc2cd5370e