### PR TITLE
Add SQLAlchemy models and repository helpers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 
 Flask>=2.0
 python-nmap>=0.7.0
+SQLAlchemy>=1.4
 

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -1,0 +1,15 @@
+"""Database utilities for NetScanOrchestrator."""
+
+from .session import get_session, init_engine
+from .models import Base, Target, ScanRun, Batch, Job, Result
+
+__all__ = [
+    "get_session",
+    "init_engine",
+    "Base",
+    "Target",
+    "ScanRun",
+    "Batch",
+    "Job",
+    "Result",
+]

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -1,0 +1,120 @@
+"""SQLAlchemy ORM models for the NetScanOrchestrator."""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    DateTime,
+    Text,
+    ForeignKey,
+    Table,
+)
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+# Association table for many-to-many relationship between batches and targets
+batch_target_association = Table(
+    "batch_target_association",
+    Base.metadata,
+    Column("batch_id", ForeignKey("batches.id"), primary_key=True),
+    Column("target_id", ForeignKey("targets.id"), primary_key=True),
+)
+
+
+class Target(Base):
+    """Represents a host or IP address that can be scanned."""
+
+    __tablename__ = "targets"
+
+    id = Column(Integer, primary_key=True)
+    address = Column(String, unique=True, nullable=False)
+    description = Column(String, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    # Relationships
+    batches = relationship(
+        "Batch",
+        secondary=batch_target_association,
+        back_populates="targets",
+    )
+    jobs = relationship("Job", back_populates="target")
+
+    def __repr__(self) -> str:  # pragma: no cover - simple repr
+        return f"<Target id={self.id} address={self.address}>"
+
+
+class ScanRun(Base):
+    """A single invocation of the scanning process."""
+
+    __tablename__ = "scan_runs"
+
+    id = Column(Integer, primary_key=True)
+    started_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    completed_at = Column(DateTime, nullable=True)
+    status = Column(String, default="pending", nullable=False)
+    options = Column(String, nullable=True)  # e.g. nmap command line options
+
+    jobs = relationship("Job", back_populates="scan_run")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<ScanRun id={self.id} status={self.status}>"
+
+
+class Batch(Base):
+    """A collection of targets that can be scanned together."""
+
+    __tablename__ = "batches"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    targets = relationship(
+        "Target",
+        secondary=batch_target_association,
+        back_populates="batches",
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<Batch id={self.id} name={self.name}>"
+
+
+class Job(Base):
+    """Represents a unit of work scanning a single target within a scan run."""
+
+    __tablename__ = "jobs"
+
+    id = Column(Integer, primary_key=True)
+    scan_run_id = Column(Integer, ForeignKey("scan_runs.id"), nullable=False)
+    target_id = Column(Integer, ForeignKey("targets.id"), nullable=False)
+    status = Column(String, default="pending", nullable=False)
+    started_at = Column(DateTime, nullable=True)
+    completed_at = Column(DateTime, nullable=True)
+
+    scan_run = relationship("ScanRun", back_populates="jobs")
+    target = relationship("Target", back_populates="jobs")
+    results = relationship("Result", back_populates="job")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<Job id={self.id} target_id={self.target_id} status={self.status}>"
+
+
+class Result(Base):
+    """Stores the outcome of a job."""
+
+    __tablename__ = "results"
+
+    id = Column(Integer, primary_key=True)
+    job_id = Column(Integer, ForeignKey("jobs.id"), nullable=False)
+    output = Column(Text, nullable=True)
+    error = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    job = relationship("Job", back_populates="results")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<Result id={self.id} job_id={self.job_id}>"

--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -1,0 +1,156 @@
+"""Convenience CRUD helpers for database models."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, Type, TypeVar, Any
+
+from sqlalchemy.orm import Session
+
+from .models import Target, ScanRun, Batch, Job, Result
+
+ModelType = TypeVar("ModelType", Target, ScanRun, Batch, Job, Result)
+
+
+def _create(session: Session, model: Type[ModelType], **kwargs: Any) -> ModelType:
+    instance = model(**kwargs)
+    session.add(instance)
+    session.commit()
+    session.refresh(instance)
+    return instance
+
+
+def _get(session: Session, model: Type[ModelType], obj_id: int) -> Optional[ModelType]:
+    return session.get(model, obj_id)
+
+
+def _list(session: Session, model: Type[ModelType]) -> List[ModelType]:
+    return session.query(model).all()
+
+
+def _update(session: Session, model: Type[ModelType], obj_id: int, **kwargs: Any) -> Optional[ModelType]:
+    instance = _get(session, model, obj_id)
+    if not instance:
+        return None
+    for key, value in kwargs.items():
+        setattr(instance, key, value)
+    session.commit()
+    return instance
+
+
+def _delete(session: Session, model: Type[ModelType], obj_id: int) -> bool:
+    instance = _get(session, model, obj_id)
+    if not instance:
+        return False
+    session.delete(instance)
+    session.commit()
+    return True
+
+
+# Target CRUD ---------------------------------------------------------------
+
+def create_target(session: Session, **kwargs: Any) -> Target:
+    return _create(session, Target, **kwargs)
+
+
+def get_target(session: Session, target_id: int) -> Optional[Target]:
+    return _get(session, Target, target_id)
+
+
+def list_targets(session: Session) -> List[Target]:
+    return _list(session, Target)
+
+
+def update_target(session: Session, target_id: int, **kwargs: Any) -> Optional[Target]:
+    return _update(session, Target, target_id, **kwargs)
+
+
+def delete_target(session: Session, target_id: int) -> bool:
+    return _delete(session, Target, target_id)
+
+
+# ScanRun CRUD --------------------------------------------------------------
+
+def create_scan_run(session: Session, **kwargs: Any) -> ScanRun:
+    return _create(session, ScanRun, **kwargs)
+
+
+def get_scan_run(session: Session, run_id: int) -> Optional[ScanRun]:
+    return _get(session, ScanRun, run_id)
+
+
+def list_scan_runs(session: Session) -> List[ScanRun]:
+    return _list(session, ScanRun)
+
+
+def update_scan_run(session: Session, run_id: int, **kwargs: Any) -> Optional[ScanRun]:
+    return _update(session, ScanRun, run_id, **kwargs)
+
+
+def delete_scan_run(session: Session, run_id: int) -> bool:
+    return _delete(session, ScanRun, run_id)
+
+
+# Batch CRUD ---------------------------------------------------------------
+
+def create_batch(session: Session, **kwargs: Any) -> Batch:
+    return _create(session, Batch, **kwargs)
+
+
+def get_batch(session: Session, batch_id: int) -> Optional[Batch]:
+    return _get(session, Batch, batch_id)
+
+
+def list_batches(session: Session) -> List[Batch]:
+    return _list(session, Batch)
+
+
+def update_batch(session: Session, batch_id: int, **kwargs: Any) -> Optional[Batch]:
+    return _update(session, Batch, batch_id, **kwargs)
+
+
+def delete_batch(session: Session, batch_id: int) -> bool:
+    return _delete(session, Batch, batch_id)
+
+
+# Job CRUD -----------------------------------------------------------------
+
+def create_job(session: Session, **kwargs: Any) -> Job:
+    return _create(session, Job, **kwargs)
+
+
+def get_job(session: Session, job_id: int) -> Optional[Job]:
+    return _get(session, Job, job_id)
+
+
+def list_jobs(session: Session) -> List[Job]:
+    return _list(session, Job)
+
+
+def update_job(session: Session, job_id: int, **kwargs: Any) -> Optional[Job]:
+    return _update(session, Job, job_id, **kwargs)
+
+
+def delete_job(session: Session, job_id: int) -> bool:
+    return _delete(session, Job, job_id)
+
+
+# Result CRUD --------------------------------------------------------------
+
+def create_result(session: Session, **kwargs: Any) -> Result:
+    return _create(session, Result, **kwargs)
+
+
+def get_result(session: Session, result_id: int) -> Optional[Result]:
+    return _get(session, Result, result_id)
+
+
+def list_results(session: Session) -> List[Result]:
+    return _list(session, Result)
+
+
+def update_result(session: Session, result_id: int, **kwargs: Any) -> Optional[Result]:
+    return _update(session, Result, result_id, **kwargs)
+
+
+def delete_result(session: Session, result_id: int) -> bool:
+    return _delete(session, Result, result_id)

--- a/src/db/session.py
+++ b/src/db/session.py
@@ -1,0 +1,41 @@
+"""Database session and engine management."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, scoped_session, Session
+
+from .models import Base
+
+DEFAULT_DB_PATH = os.path.join(".netscan_orchestrator", "state.db")
+
+_engine = None  # type: ignore
+_SessionFactory = None  # type: ignore
+
+
+def init_engine(db_path: Optional[str] = None):
+    """Initialise the SQLAlchemy engine and create tables if required."""
+    global _engine, _SessionFactory
+    if _engine is not None:
+        return _engine
+
+    path = db_path or DEFAULT_DB_PATH
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    url = f"sqlite:///{path}"
+    _engine = create_engine(url, connect_args={"check_same_thread": False})
+    _SessionFactory = scoped_session(sessionmaker(bind=_engine))
+
+    # Create tables on first use
+    Base.metadata.create_all(_engine)
+    return _engine
+
+
+def get_session(db_path: Optional[str] = None) -> Session:
+    """Return a new SQLAlchemy session, initialising the engine if needed."""
+    if _engine is None:
+        init_engine(db_path)
+    assert _SessionFactory is not None  # for type checkers
+    return _SessionFactory()


### PR DESCRIPTION
## Summary
- define SQLAlchemy ORM models for targets, scan runs, batches, jobs and results
- create session utility to initialize a SQLite database and manage sessions
- implement CRUD repository functions for each model and add SQLAlchemy dependency

## Testing
- `pytest -q` *(fails: No hosts found in scan results. Nmap command not found)*
- `pytest tests/test_ip_handler.py::TestIPHandler -q`


------
https://chatgpt.com/codex/tasks/task_b_689dcb6f9d648321b8900a147c7a88f2