### PR TITLE
Add SQLite repository tests

### DIFF
--- a/src/db_repository.py
+++ b/src/db_repository.py
@@ -1,0 +1,63 @@
+import sqlite3
+from typing import Optional, List, Dict, Any
+
+
+class DBRepository:
+    """Simple repository for storing scan hosts in SQLite."""
+
+    def __init__(self, connection: sqlite3.Connection):
+        self.conn = connection
+        self._create_tables()
+
+    def _create_tables(self) -> None:
+        cursor = self.conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS hosts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ip TEXT UNIQUE NOT NULL,
+                status TEXT NOT NULL
+            )
+            """
+        )
+        self.conn.commit()
+
+    # CRUD operations
+    def add_host(self, ip: str, status: str) -> int:
+        cursor = self.conn.cursor()
+        cursor.execute("INSERT INTO hosts (ip, status) VALUES (?, ?)", (ip, status))
+        self.conn.commit()
+        return cursor.lastrowid
+
+    def get_host_by_ip(self, ip: str) -> Optional[Dict[str, Any]]:
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT id, ip, status FROM hosts WHERE ip = ?", (ip,))
+        row = cursor.fetchone()
+        if row:
+            return {"id": row[0], "ip": row[1], "status": row[2]}
+        return None
+
+    def update_host_status(self, ip: str, status: str) -> bool:
+        cursor = self.conn.cursor()
+        cursor.execute("UPDATE hosts SET status = ? WHERE ip = ?", (status, ip))
+        self.conn.commit()
+        return cursor.rowcount > 0
+
+    def delete_host(self, ip: str) -> bool:
+        cursor = self.conn.cursor()
+        cursor.execute("DELETE FROM hosts WHERE ip = ?", (ip,))
+        self.conn.commit()
+        return cursor.rowcount > 0
+
+    # Helper queries
+    def get_hosts_by_status(self, status: str) -> List[Dict[str, Any]]:
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT id, ip, status FROM hosts WHERE status = ?", (status,))
+        rows = cursor.fetchall()
+        return [{"id": r[0], "ip": r[1], "status": r[2]} for r in rows]
+
+    def list_hosts(self) -> List[Dict[str, Any]]:
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT id, ip, status FROM hosts")
+        rows = cursor.fetchall()
+        return [{"id": r[0], "ip": r[1], "status": r[2]} for r in rows]

--- a/tests/test_db_repository.py
+++ b/tests/test_db_repository.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import sqlite3
+import unittest
+
+# Ensure src is importable
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, project_root)
+
+from src.db_repository import DBRepository
+
+
+class TestDBRepository(unittest.TestCase):
+    def setUp(self):
+        self.conn = sqlite3.connect(':memory:')
+        self.repo = DBRepository(self.conn)
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_table_creation(self):
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='hosts'")
+        self.assertIsNotNone(cursor.fetchone())
+
+    def test_crud_operations(self):
+        self.repo.add_host('1.1.1.1', 'up')
+        host = self.repo.get_host_by_ip('1.1.1.1')
+        self.assertIsNotNone(host)
+        self.assertEqual(host['status'], 'up')
+
+        updated = self.repo.update_host_status('1.1.1.1', 'down')
+        self.assertTrue(updated)
+        host = self.repo.get_host_by_ip('1.1.1.1')
+        self.assertEqual(host['status'], 'down')
+
+        deleted = self.repo.delete_host('1.1.1.1')
+        self.assertTrue(deleted)
+        self.assertIsNone(self.repo.get_host_by_ip('1.1.1.1'))
+
+    def test_helper_query_get_hosts_by_status(self):
+        self.repo.add_host('1.1.1.1', 'up')
+        self.repo.add_host('2.2.2.2', 'down')
+        self.repo.add_host('3.3.3.3', 'up')
+
+        up_hosts = self.repo.get_hosts_by_status('up')
+        ips = sorted([h['ip'] for h in up_hosts])
+        self.assertEqual(ips, ['1.1.1.1', '3.3.3.3'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement simple SQLite-backed `DBRepository`
- add tests for model creation, CRUD operations and helper query using in-memory database

## Testing
- `GITHUB_ACTIONS=true pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689dcb76bf4c83219eb6a5f4767ecf0f