### PR TITLE
feat(cli): initialize state DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Nmap Parallel Scanner is a Python-based framework designed to run Nmap scans aga
 - **Scan Management:** Offers insights into scan coverage, detailing which IPs were successfully scanned, which failed, and which remain unscanned.
 - **Docker Support:** Can be built and run as a Docker container, bundling Nmap and all dependencies.
 
+## State Database
+
+The CLI persists targets and scan metadata in a SQLite database. By default the database file is created at `.netscan_orchestrator/state.db` in the current working directory. Use the `--db-path` option to point to a different location if needed. The database and its parent directory are created automatically on first use.
+
 ## Architecture Overview
 
 The Nmap Parallel Scanner consists of several core components:

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -3,7 +3,7 @@ import typer
 
 from sqlalchemy.orm import Session
 
-from ..db.session import init_engine, get_session
+from ..db.session import init_engine, get_session, DEFAULT_DB_PATH
 from ..db import repository as db_repo
 
 app = typer.Typer(help="NetScan Orchestrator CLI")
@@ -13,14 +13,14 @@ app = typer.Typer(help="NetScan Orchestrator CLI")
 def main(
     ctx: typer.Context,
     db_path: Path = typer.Option(
-        None,
+        Path(DEFAULT_DB_PATH),
         "--db-path",
         help="Path to SQLite state database",
         dir_okay=False,
     ),
 ):
     """Initialise the database engine and attach a session to context."""
-    init_engine(str(db_path) if db_path else None)
+    init_engine(str(db_path))
     ctx.obj = get_session()
 
 


### PR DESCRIPTION
## Summary
- initialize SQLite engine on CLI startup with configurable `--db-path`
- document default state database location and persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689ddc973ffc8321a73c12cd7c0972f3