### PR TITLE
Add reporting module and status CLI command

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -1,10 +1,13 @@
 from pathlib import Path
+from typing import Optional
+
 import typer
 
 from sqlalchemy.orm import Session
 
 from ..db.session import init_engine, get_session
 from ..db import repository as db_repo
+from .. import reporting
 
 app = typer.Typer(help="NetScan Orchestrator CLI")
 
@@ -82,6 +85,66 @@ def run(ctx: typer.Context, scan_run_id: int):
             )
             jobs_created += 1
     typer.echo(f"Executed {len(batches)} batches")
+
+
+@app.command()
+def status(
+    ctx: typer.Context,
+    json_out: Optional[Path] = typer.Option(
+        None, "--json-out", help="Write summary information to JSON file", dir_okay=False
+    ),
+    csv_out: Optional[Path] = typer.Option(
+        None, "--csv-out", help="Write run summary to CSV file", dir_okay=False
+    ),
+):
+    """Display a summary of scan runs, jobs and failures."""
+
+    session: Session = ctx.obj
+
+    run_summary = reporting.summarise_runs(session)
+    slowest_jobs = reporting.get_slowest_jobs(session)
+    failed_jobs = reporting.get_failed_jobs(session)
+    export_payload = {
+        "runs": run_summary,
+        "slowest_jobs": slowest_jobs,
+        "failed_jobs": failed_jobs,
+    }
+
+    if json_out:
+        reporting.export_json(export_payload, str(json_out))
+    if csv_out:
+        reporting.export_csv(run_summary, str(csv_out))
+
+    typer.echo("ScanRun Summary")
+    if run_summary:
+        typer.echo(f"{'Run':<5} {'Total':<6} {'Completed':<9} {'Failed':<6}")
+        for row in run_summary:
+            typer.echo(
+                f"{row['scan_run_id']:<5} {row['total_jobs']:<6} {row['completed_jobs']:<9} {row['failed_jobs']:<6}"
+            )
+    else:
+        typer.echo("No ScanRuns found")
+
+    typer.echo("\nSlowest Jobs")
+    if slowest_jobs:
+        typer.echo(f"{'Job':<5} {'Run':<5} {'Target':<15} {'Duration':<8}")
+        for row in slowest_jobs:
+            duration = row['duration'] if row['duration'] is not None else 0.0
+            typer.echo(
+                f"{row['job_id']:<5} {row['scan_run_id']:<5} {row['target']:<15} {duration:<8.2f}"
+            )
+    else:
+        typer.echo("No job durations")
+
+    typer.echo("\nFailed Jobs")
+    if failed_jobs:
+        typer.echo(f"{'Job':<5} {'Run':<5} {'Target':<15} {'Error'}")
+        for row in failed_jobs:
+            typer.echo(
+                f"{row['job_id']:<5} {row['scan_run_id']:<5} {row['target']:<15} {row['error'] or ''}"
+            )
+    else:
+        typer.echo("No failed jobs")
 
 
 if __name__ == "__main__":

--- a/src/reporting.py
+++ b/src/reporting.py
@@ -1,0 +1,185 @@
+"""Reporting utilities for summarising database state.
+
+This module exposes convenience functions that inspect the SQLAlchemy
+models and generate useful statistics.  It is intentionally lightweight
+so it can be used both from the CLI and from tests.
+
+The helpers mirror the export functionality found in
+:mod:`src.results_handler` by providing simple JSON and CSV writers.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+import csv
+import json
+
+from sqlalchemy.orm import Session
+
+from .db.models import ScanRun, Batch, Job
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _job_duration(job: Job) -> Optional[float]:
+    """Return the job duration in seconds if timestamps are available."""
+
+    if job.started_at and job.completed_at:
+        return (job.completed_at - job.started_at).total_seconds()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Query helpers
+# ---------------------------------------------------------------------------
+
+def get_slowest_jobs(session: Session, limit: int = 5) -> List[Dict[str, Any]]:
+    """Return the ``limit`` slowest jobs sorted by duration."""
+
+    jobs = session.query(Job).all()
+    jobs_with_durations = [j for j in jobs if _job_duration(j) is not None]
+    jobs_with_durations.sort(key=lambda j: _job_duration(j), reverse=True)
+
+    rows: List[Dict[str, Any]] = []
+    for job in jobs_with_durations[:limit]:
+        rows.append(
+            {
+                "job_id": job.id,
+                "scan_run_id": job.scan_run_id,
+                "target": job.target.address if job.target else None,
+                "duration": _job_duration(job),
+                "status": job.status,
+            }
+        )
+    return rows
+
+
+def get_failed_jobs(session: Session) -> List[Dict[str, Any]]:
+    """Return jobs that are not completed successfully along with errors."""
+
+    jobs = session.query(Job).all()
+    failed: List[Dict[str, Any]] = []
+    for job in jobs:
+        # A job is failed if its status is not 'completed' or if any associated
+        # result contains an error message.  We inspect ``results`` relationship
+        # in Python to avoid complex SQL for this educational project.
+        error: Optional[str] = None
+        for res in job.results:
+            if res.error:
+                error = res.error
+                break
+        if job.status != "completed" or error:
+            failed.append(
+                {
+                    "job_id": job.id,
+                    "scan_run_id": job.scan_run_id,
+                    "target": job.target.address if job.target else None,
+                    "status": job.status,
+                    "error": error,
+                }
+            )
+    return failed
+
+
+def summarise_runs(session: Session) -> List[Dict[str, Any]]:
+    """Return a summary per :class:`~src.db.models.ScanRun`."""
+
+    rows: List[Dict[str, Any]] = []
+    for run in session.query(ScanRun).all():
+        total_jobs = len(run.jobs)
+        completed = sum(1 for j in run.jobs if j.status == "completed")
+        failed = total_jobs - completed
+        rows.append(
+            {
+                "scan_run_id": run.id,
+                "total_jobs": total_jobs,
+                "completed_jobs": completed,
+                "failed_jobs": failed,
+            }
+        )
+    return rows
+
+
+def summarise_batches(session: Session) -> List[Dict[str, Any]]:
+    """Return a summary per :class:`~src.db.models.Batch`."""
+
+    rows: List[Dict[str, Any]] = []
+    for batch in session.query(Batch).all():
+        job_count = sum(len(t.jobs) for t in batch.targets)
+        rows.append(
+            {
+                "batch_id": batch.id,
+                "name": batch.name,
+                "target_count": len(batch.targets),
+                "job_count": job_count,
+            }
+        )
+    return rows
+
+
+def summarise_jobs(session: Session) -> List[Dict[str, Any]]:
+    """Return a list of individual job records."""
+
+    rows: List[Dict[str, Any]] = []
+    for job in session.query(Job).all():
+        duration = _job_duration(job)
+        error = None
+        for res in job.results:
+            if res.error:
+                error = res.error
+                break
+        rows.append(
+            {
+                "job_id": job.id,
+                "scan_run_id": job.scan_run_id,
+                "target": job.target.address if job.target else None,
+                "status": job.status,
+                "duration": duration,
+                "error": error,
+            }
+        )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Export helpers
+# ---------------------------------------------------------------------------
+
+def export_json(data: Any, output_filepath: str) -> None:
+    """Write ``data`` to ``output_filepath`` in JSON format."""
+
+    with open(output_filepath, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=4)
+
+
+def export_csv(rows: List[Dict[str, Any]], output_filepath: str) -> None:
+    """Write list of dictionaries to ``output_filepath`` as CSV."""
+
+    if not rows:
+        # Create an empty file with no headers
+        open(output_filepath, "w").close()
+        return
+
+    fieldnames: List[str] = []
+    for row in rows:
+        for key in row.keys():
+            if key not in fieldnames:
+                fieldnames.append(key)
+
+    with open(output_filepath, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+__all__ = [
+    "get_slowest_jobs",
+    "get_failed_jobs",
+    "summarise_runs",
+    "summarise_batches",
+    "summarise_jobs",
+    "export_json",
+    "export_csv",
+]

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -1,0 +1,46 @@
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+class TestCLIStatusCommand(unittest.TestCase):
+    def setUp(self):
+        self.project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        self.input_file = os.path.join(self.project_root, "tests", "test_data", "integration_test_ips.txt")
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        tmp.close()
+        self.db_path = tmp.name
+
+    def tearDown(self):
+        if os.path.exists(self.db_path):
+            os.unlink(self.db_path)
+
+    def run_cli(self, *args):
+        cmd = [
+            sys.executable,
+            "-m",
+            "src.cli.main",
+            "--db-path",
+            self.db_path,
+            *map(str, args),
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, msg=f"Command {' '.join(cmd)} failed with {result.stderr}")
+        return result.stdout
+
+    def test_status_command_outputs_tables(self):
+        self.run_cli("ingest", self.input_file)
+        output = self.run_cli("plan")
+        run_id = int(output.split()[-1])
+        self.run_cli("split", run_id, "--chunk-size", "1")
+        self.run_cli("run", run_id)
+        status_output = self.run_cli("status")
+        self.assertIn("ScanRun Summary", status_output)
+        self.assertIn("No job durations", status_output)
+        self.assertIn("No failed jobs", status_output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,69 @@
+import os
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+
+from src.db.session import init_engine, get_session
+from src.db import repository as db_repo
+from src import reporting
+
+
+class TestReportingModule(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        tmp.close()
+        self.db_path = tmp.name
+        init_engine(self.db_path)
+        self.session = get_session()
+
+    def tearDown(self):
+        self.session.close()
+        if os.path.exists(self.db_path):
+            os.unlink(self.db_path)
+
+    def test_summary_queries_and_exports(self):
+        run = db_repo.create_scan_run(self.session, status="completed")
+        t1 = db_repo.create_target(self.session, address="1.1.1.1")
+        t2 = db_repo.create_target(self.session, address="2.2.2.2")
+        start = datetime.utcnow()
+        db_repo.create_job(
+            self.session,
+            scan_run_id=run.id,
+            target_id=t1.id,
+            status="completed",
+            started_at=start,
+            completed_at=start + timedelta(seconds=5),
+        )
+        j2 = db_repo.create_job(
+            self.session,
+            scan_run_id=run.id,
+            target_id=t2.id,
+            status="failed",
+            started_at=start,
+            completed_at=start + timedelta(seconds=10),
+        )
+        db_repo.create_result(self.session, job_id=j2.id, error="timeout")
+
+        runs = reporting.summarise_runs(self.session)
+        self.assertEqual(runs[0]["failed_jobs"], 1)
+
+        slowest = reporting.get_slowest_jobs(self.session)
+        self.assertEqual(slowest[0]["job_id"], j2.id)
+
+        failed = reporting.get_failed_jobs(self.session)
+        self.assertEqual(failed[0]["error"], "timeout")
+
+        tmp_json = tempfile.NamedTemporaryFile(delete=False)
+        tmp_json.close()
+        tmp_csv = tempfile.NamedTemporaryFile(delete=False)
+        tmp_csv.close()
+        reporting.export_json(runs, tmp_json.name)
+        reporting.export_csv(runs, tmp_csv.name)
+        self.assertTrue(os.path.getsize(tmp_json.name) > 0)
+        self.assertTrue(os.path.getsize(tmp_csv.name) > 0)
+        os.unlink(tmp_json.name)
+        os.unlink(tmp_csv.name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `reporting` module to gather run and job statistics
- export summaries to JSON or CSV
- provide `netscan status` CLI command for tabular reports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689ddc8b3ce48321b89f7b6dad2ee65d