### PR TITLE
Capture detailed stdout and stderr for jobs

### DIFF
--- a/src/db/models.py
+++ b/src/db/models.py
@@ -110,8 +110,9 @@ class Result(Base):
 
     id = Column(Integer, primary_key=True)
     job_id = Column(Integer, ForeignKey("jobs.id"), nullable=False)
-    output = Column(Text, nullable=True)
-    error = Column(Text, nullable=True)
+    stdout = Column(Text, nullable=True)
+    stderr = Column(Text, nullable=True)
+    summary_json = Column(Text, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
 
     job = relationship("Job", back_populates="results")


### PR DESCRIPTION
## Summary
- replace `Result.output`/`Result.error` with `stdout`, `stderr`, and `summary_json`
- populate these fields in CLI job execution after each scan finishes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689ddc74df1c8321ba4336278a55fe00