### PR TITLE
Add recursive batch splitting with strategy tracking

### DIFF
--- a/src/db/models.py
+++ b/src/db/models.py
@@ -72,6 +72,14 @@ class Batch(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String, unique=True, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    parent_batch_id = Column(Integer, ForeignKey("batches.id"), nullable=True)
+    strategy = Column(String, nullable=True)
+
+    # Self-referential relationships to support recursive splitting
+    parent = relationship("Batch", remote_side=[id], back_populates="children")
+    children = relationship(
+        "Batch", back_populates="parent", cascade="all, delete-orphan"
+    )
 
     targets = relationship(
         "Target",
@@ -80,7 +88,10 @@ class Batch(Base):
     )
 
     def __repr__(self) -> str:  # pragma: no cover
-        return f"<Batch id={self.id} name={self.name}>"
+        return (
+            f"<Batch id={self.id} name={self.name} parent={self.parent_batch_id}"
+            f" strategy={self.strategy}>"
+        )
 
 
 class Job(Base):

--- a/tests/test_resplit_cli.py
+++ b/tests/test_resplit_cli.py
@@ -1,0 +1,71 @@
+import os
+import os
+import subprocess
+import sys
+import tempfile
+import sqlite3
+import unittest
+
+
+class TestResplitCLI(unittest.TestCase):
+    def setUp(self):
+        self.project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        tmp_db = tempfile.NamedTemporaryFile(delete=False)
+        tmp_db.close()
+        self.db_path = tmp_db.name
+        # Create temp file with multiple IPs
+        tmp_file = tempfile.NamedTemporaryFile(delete=False, mode='w')
+        tmp_file.write('192.168.0.1\n192.168.0.2\n')
+        tmp_file.close()
+        self.input_file = tmp_file.name
+
+    def tearDown(self):
+        for path in [self.db_path, self.input_file]:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def run_cli(self, *args):
+        cmd = [
+            sys.executable,
+            '-m',
+            'src.cli.main',
+            '--db-path',
+            self.db_path,
+            *map(str, args),
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, msg=f"Command {' '.join(cmd)} failed with {result.stderr}")
+        return result.stdout.strip()
+
+    def test_resplit_creates_child_batches(self):
+        # ingest and plan
+        self.run_cli('ingest', self.input_file)
+        run_id = int(self.run_cli('plan').split()[-1])
+        # initial split to create single batch containing both targets
+        self.run_cli('split', run_id, '--chunk-size', '2')
+        # fetch parent batch id
+        conn = sqlite3.connect(self.db_path)
+        cur = conn.cursor()
+        cur.execute('SELECT id, parent_batch_id, strategy FROM batches')
+        parent = cur.fetchone()
+        self.assertIsNotNone(parent)
+        parent_id, parent_parent_id, parent_strategy = parent
+        self.assertIsNone(parent_parent_id)
+        self.assertEqual(parent_strategy, 'initial')
+        conn.close()
+        # resplit parent batch into child batches of size 1
+        self.run_cli('resplit', parent_id, '--chunk-size', '1')
+        # verify child batches
+        conn = sqlite3.connect(self.db_path)
+        cur = conn.cursor()
+        cur.execute('SELECT id, parent_batch_id, strategy FROM batches WHERE parent_batch_id = ?', (parent_id,))
+        children = cur.fetchall()
+        self.assertEqual(len(children), 2)
+        for child in children:
+            self.assertEqual(child[1], parent_id)
+            self.assertEqual(child[2], 'resplit')
+        conn.close()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `parent_batch_id` and `strategy` fields to batches and define self-referential relationships
- extend `split` and new `resplit` CLI commands to populate batch strategy and hierarchy
- cover recursive batch splitting via new CLI test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689ddc76ebc48321b32db69027722ad6