### PR TITLE
feat(cli): add job scheduling options

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,29 @@ python nmap_parallel_scanner.py [OPTIONS]
         --nmap-options "-sS -A -T3"
     ```
 
+### Orchestration CLI
+
+For database-backed experimentation the repository also provides a small
+Typer-based CLI:
+
+```bash
+python -m src.cli.main [OPTIONS] COMMAND [ARGS]
+```
+
+The ``run`` command executes all pending batches for a scan run.  It now
+exposes two options for basic scheduling:
+
+* ``--max-procs`` – maximum number of scan jobs to execute concurrently
+  (default: ``1``).
+* ``--rate-limit`` – jobs to start per second; ``0`` disables rate
+  limiting (default: ``0``).
+
+Example:
+
+```bash
+python -m src.cli.main run 1 --max-procs 4 --rate-limit 2
+```
+
 ### Web Interface (for viewing results)
 
 The web UI is a simple Flask application to view *previously generated JSON results*. It does not initiate scans.

--- a/src/runner.py
+++ b/src/runner.py
@@ -1,0 +1,89 @@
+"""Job execution helpers with simple scheduling.
+
+This module provides a helper to run scan jobs while limiting the
+number of simultaneous workers and optionally rate limiting job
+submissions.  The actual scanning work is intentionally minimal in
+tests; the focus is on the scheduling behaviour which mimics what a
+real scanner would need.
+"""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Iterable
+
+from sqlalchemy.orm import Session
+
+from .db import repository as db_repo
+
+
+def run_batches(
+    session: Session,
+    scan_run_id: int,
+    batches: Iterable,
+    *,
+    max_procs: int = 1,
+    rate_limit: float = 0.0,
+) -> int:
+    """Execute jobs for all targets in *batches*.
+
+    Parameters
+    ----------
+    session:
+        Database session used to record :class:`~src.db.models.Job` entries.
+    scan_run_id:
+        Identifier of the :class:`~src.db.models.ScanRun` the jobs belong to.
+    batches:
+        Iterable of :class:`~src.db.models.Batch` instances whose targets will
+        be scanned.
+    max_procs:
+        Maximum number of jobs to run simultaneously.  Values less than ``1``
+        are treated as ``1``.
+    rate_limit:
+        Maximum number of jobs to start per second.  A value of ``0`` disables
+        rate limiting.
+
+    Returns
+    -------
+    int
+        Number of jobs that were executed.
+    """
+
+    workers = max(1, int(max_procs))
+    delay = 1.0 / rate_limit if rate_limit > 0 else 0.0
+
+    def _scan(target) -> int:
+        """Placeholder for real scan work.
+
+        In the real implementation this would invoke a network scanner.  For
+        the purposes of the kata and tests it simply returns immediately after
+        an optional tiny sleep.
+        """
+        if delay:
+            # Sleep is handled before submission for rate limiting; keep the
+            # worker fast.  The sleep here is merely defensive in case a real
+            # scan is swapped in that needs to respect pacing itself.
+            pass
+        return target.id
+
+    futures = []
+    last_launch = 0.0
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        for batch in batches:
+            for target in batch.targets:
+                if delay:
+                    now = time.monotonic()
+                    wait = (last_launch + delay) - now
+                    if wait > 0:
+                        time.sleep(wait)
+                    last_launch = time.monotonic()
+                futures.append((target.id, executor.submit(_scan, target)))
+
+        for target_id, fut in futures:
+            fut.result()  # Propagate worker exceptions if any
+            db_repo.create_job(
+                session, scan_run_id=scan_run_id, target_id=target_id, status="completed"
+            )
+
+    return len(futures)

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -39,8 +39,8 @@ class TestTyperCLI(unittest.TestCase):
         run_id = int(output.split()[-1])
         # split into batches of size 1
         self.run_cli("split", run_id, "--chunk-size", "1")
-        # run all batches
-        self.run_cli("run", run_id)
+        # run all batches with custom scheduling options
+        self.run_cli("run", run_id, "--max-procs", "2", "--rate-limit", "10")
 
         conn = sqlite3.connect(self.db_path)
         cur = conn.cursor()


### PR DESCRIPTION
## Summary
- add a runner helper that enforces concurrent job and rate limits
- extend `run` CLI command with `--max-procs` and `--rate-limit`
- document orchestration CLI options in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_689ddc9662b08321891687a1fcdb89b5