### PR TITLE
Add planner module with batch splitting and resplit CLI

### DIFF
--- a/src/db/models.py
+++ b/src/db/models.py
@@ -72,12 +72,16 @@ class Batch(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String, unique=True, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    parent_batch_id = Column(Integer, ForeignKey("batches.id"), nullable=True)
+    strategy = Column(String, nullable=True)
 
     targets = relationship(
         "Target",
         secondary=batch_target_association,
         back_populates="batches",
     )
+    jobs = relationship("Job", back_populates="batch")
+    parent = relationship("Batch", remote_side=[id], backref="children")
 
     def __repr__(self) -> str:  # pragma: no cover
         return f"<Batch id={self.id} name={self.name}>"
@@ -90,12 +94,14 @@ class Job(Base):
 
     id = Column(Integer, primary_key=True)
     scan_run_id = Column(Integer, ForeignKey("scan_runs.id"), nullable=False)
+    batch_id = Column(Integer, ForeignKey("batches.id"), nullable=False)
     target_id = Column(Integer, ForeignKey("targets.id"), nullable=False)
     status = Column(String, default="pending", nullable=False)
     started_at = Column(DateTime, nullable=True)
     completed_at = Column(DateTime, nullable=True)
 
     scan_run = relationship("ScanRun", back_populates="jobs")
+    batch = relationship("Batch", back_populates="jobs")
     target = relationship("Target", back_populates="jobs")
     results = relationship("Result", back_populates="job")
 

--- a/src/planner.py
+++ b/src/planner.py
@@ -1,0 +1,71 @@
+"""Planning utilities for creating and splitting scan batches."""
+
+from __future__ import annotations
+
+from typing import List
+
+from sqlalchemy.orm import Session
+
+from .db import repository as db_repo
+from .db.models import Batch, Job
+
+
+def create_initial_batches(session: Session, *, chunk_size: int, strategy: str) -> List[Batch]:
+    """Create initial batches from all targets.
+
+    Args:
+        session: Database session.
+        chunk_size: Maximum number of targets per batch.
+        strategy: Strategy string to store on each batch.
+
+    Returns:
+        List of created Batch instances.
+    """
+    targets = db_repo.list_targets(session)
+    batches: List[Batch] = []
+    for idx in range(0, len(targets), chunk_size):
+        batch_targets = targets[idx : idx + chunk_size]
+        batch = db_repo.create_batch(
+            session,
+            name=f"batch{idx // chunk_size + 1}",
+            targets=batch_targets,
+            strategy=strategy,
+        )
+        batches.append(batch)
+    return batches
+
+
+def resplit_job(session: Session, job_id: int) -> List[Batch]:
+    """Binary split the batch for the given job into two new batches.
+
+    The original batch has its targets cleared to avoid re-processing.
+
+    Args:
+        session: Database session.
+        job_id: Identifier of the job whose batch should be split.
+
+    Returns:
+        List of newly created Batch instances (empty if no split performed).
+    """
+    job: Job | None = db_repo.get_job(session, job_id)
+    if not job or not job.batch:
+        return []
+    batch = job.batch
+    if len(batch.targets) <= 1:
+        return []
+    mid = len(batch.targets) // 2
+    targets1 = list(batch.targets[:mid])
+    targets2 = list(batch.targets[mid:])
+    new_batches: List[Batch] = []
+    for i, target_list in enumerate((targets1, targets2), start=1):
+        new_batch = db_repo.create_batch(
+            session,
+            name=f"{batch.name}_split{i}",
+            targets=target_list,
+            strategy=batch.strategy,
+            parent_batch_id=batch.id,
+        )
+        new_batches.append(new_batch)
+    batch.targets = []
+    session.commit()
+    return new_batches

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,67 @@
+import os
+import tempfile
+import unittest
+
+from src import planner
+from src.db.session import init_engine, get_session
+from src.db import repository as db_repo
+from src.db.models import Base
+
+
+class PlannerTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.NamedTemporaryFile(delete=False)
+        cls.tmp.close()
+        init_engine(cls.tmp.name)
+
+    @classmethod
+    def tearDownClass(cls):
+        os.unlink(cls.tmp.name)
+
+    def setUp(self):
+        self.session = get_session()
+        engine = self.session.get_bind()
+        Base.metadata.drop_all(bind=engine)
+        Base.metadata.create_all(bind=engine)
+
+    def tearDown(self):
+        self.session.close()
+
+    def _create_targets(self, count: int):
+        for i in range(count):
+            db_repo.create_target(self.session, address=f"10.0.0.{i}")
+
+    def test_create_initial_batches(self):
+        self._create_targets(3)
+        batches = planner.create_initial_batches(self.session, chunk_size=2, strategy="test")
+        self.assertEqual(len(batches), 2)
+        self.assertEqual(batches[0].strategy, "test")
+        self.assertEqual(len(batches[0].targets), 2)
+        self.assertEqual(len(batches[1].targets), 1)
+
+    def test_resplit_job_creates_child_batches(self):
+        self._create_targets(4)
+        run = db_repo.create_scan_run(self.session, status="planned")
+        batches = planner.create_initial_batches(self.session, chunk_size=4, strategy="orig")
+        batch = batches[0]
+        # Create a job associated with this batch
+        job = db_repo.create_job(
+            self.session,
+            scan_run_id=run.id,
+            batch_id=batch.id,
+            target_id=batch.targets[0].id,
+            status="timeout",
+        )
+        new_batches = planner.resplit_job(self.session, job.id)
+        self.assertEqual(len(new_batches), 2)
+        for nb in new_batches:
+            self.assertEqual(nb.parent_batch_id, batch.id)
+            self.assertEqual(nb.strategy, batch.strategy)
+        # Parent batch should have no targets after split
+        refreshed_parent = db_repo.get_batch(self.session, batch.id)
+        self.assertEqual(len(refreshed_parent.targets), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add planner utilities to create initial batches and resplit timed-out jobs into two halves
- extend Batch and Job models with parent linkage, strategy, and batch associations
- update CLI to plan batches directly and expose a resplit command; run now records batch IDs
- cover planning logic and CLI resplit with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ddc82bc4083219da10cf59610c609