### PR TITLE
Fix imports and add minimal CLI with in-memory DB

### DIFF
--- a/nmap_parallel_scanner.py
+++ b/nmap_parallel_scanner.py
@@ -32,15 +32,15 @@ except ImportError:
         sys.exit(1)
 
 
-from src.ip_handler import read_ips_from_file, chunk_ips # Now should work with src prefix
+from src.ip_handler import read_ips_from_file, chunk_ips  # Now should work with src prefix
 from src.parallel_scanner import scan_chunks_parallel
-from results_handler import (
+from src.results_handler import (
     consolidate_scan_results,
     to_json,
     to_csv,
     to_txt,
     to_markdown,
-    to_xml
+    to_xml,
 )
 
 def main():
@@ -229,4 +229,3 @@ if __name__ == "__main__":
     # This allows the script to be run directly.
     # For a packaged application, entry points in setup.py would be used.
     main()
-```

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI package for NetScanOrchestrator."""

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -1,0 +1,32 @@
+"""Command line interface for NetScanOrchestrator."""
+import argparse
+
+from ..ip_handler import read_ips_from_file
+from ..db import repository as db_repo
+
+
+def ingest_command(file_path: str) -> None:
+    """Ingest targets from a file into the in-memory repository."""
+    ips = read_ips_from_file(file_path)
+    if not ips:
+        print("No IPs to ingest.")
+        return
+    count = db_repo.add_targets(ips)
+    print(f"Ingested {count} target(s).")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="NetScanOrchestrator CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    ingest_parser = subparsers.add_parser("ingest", help="Ingest targets from a file")
+    ingest_parser.add_argument("file", help="Path to file containing IPs or hostnames")
+
+    args = parser.parse_args()
+
+    if args.command == "ingest":
+        ingest_command(args.file)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -1,0 +1,4 @@
+"""In-memory data store for NetScanOrchestrator."""
+from .repository import add_targets, get_targets  # re-export for convenience
+
+__all__ = ["add_targets", "get_targets"]

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -1,0 +1,27 @@
+"""Data models for the in-memory repository."""
+from dataclasses import dataclass
+
+
+@dataclass
+class Target:
+    ip: str
+
+
+@dataclass
+class ScanRun:
+    id: int = 0
+
+
+@dataclass
+class Batch:
+    id: int = 0
+
+
+@dataclass
+class Job:
+    id: int = 0
+
+
+@dataclass
+class Result:
+    id: int = 0

--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -1,0 +1,21 @@
+"""Simple in-memory repository for storing scan targets and results."""
+from __future__ import annotations
+
+from typing import List
+
+from .models import Target, ScanRun, Batch, Job, Result
+
+# In-memory stores
+_TARGETS: List[Target] = []
+
+
+def add_targets(ips: List[str]) -> int:
+    """Add a list of IP strings as Targets to the repository."""
+    for ip in ips:
+        _TARGETS.append(Target(ip=ip))
+    return len(ips)
+
+
+def get_targets() -> List[Target]:
+    """Return all stored Targets."""
+    return list(_TARGETS)

--- a/src/parallel_scanner.py
+++ b/src/parallel_scanner.py
@@ -1,6 +1,7 @@
 import multiprocessing
-from src.nmap_scanner import run_nmap_scan
 from typing import List, Dict
+
+from .nmap_scanner import run_nmap_scan
 # We might need to wrap run_nmap_scan or pass arguments carefully for starmap
 # For now, let's assume we'll adapt the call within scan_chunks_parallel
 

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import json
 import sys
+import shutil
 
 class TestCLIIntegration(unittest.TestCase):
 
@@ -34,7 +35,10 @@ class TestCLIIntegration(unittest.TestCase):
     def tearDown(self):
         self.temp_output_dir_obj.cleanup()
 
-    @unittest.skipIf(os.getenv('GITHUB_ACTIONS') == 'true', "Skipping live Nmap scan in GitHub Actions to avoid network issues/blocks.")
+    @unittest.skipIf(
+        os.getenv('GITHUB_ACTIONS') == 'true' or shutil.which('nmap') is None,
+        "Skipping live Nmap scan in CI or when Nmap is unavailable."
+    )
     def test_scanner_runs_and_produces_valid_json_output(self):
         """
         Tests if the CLI scanner runs, produces a JSON output for scanme.nmap.org,
@@ -144,4 +148,3 @@ class TestCLIIntegration(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-```

--- a/tests/test_ip_handler.py
+++ b/tests/test_ip_handler.py
@@ -123,4 +123,3 @@ if __name__ == "__main__":
     # This allows running the tests directly from this file: python tests/test_ip_handler.py
     # It's also discoverable by `python -m unittest discover tests` from project root.
     unittest.main()
-```

--- a/tests/test_results_handler.py
+++ b/tests/test_results_handler.py
@@ -175,4 +175,3 @@ class TestResultsHandler(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-```


### PR DESCRIPTION
## Summary
- fix import paths for internal modules
- add simple CLI and in-memory repository for target ingestion
- clean up tests and skip integration when nmap missing

## Testing
- `python -m src.cli.main ingest data/sample_inputs/example_ips.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689df8e7c9f48321a221b727dd655d68