### PR TITLE
Add new scan wizard with API integration

### DIFF
--- a/web_ui/client/src/pages/NewScanPage.tsx
+++ b/web_ui/client/src/pages/NewScanPage.tsx
@@ -1,27 +1,151 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { startScan, ScanOptions } from '../services/api';
 
 export function NewScanPage() {
-  const handleTestApiCall = async () => {
+  const navigate = useNavigate();
+
+  const prefersReducedMotion =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const [targets, setTargets] = useState<string[]>(['']);
+  const [options, setOptions] = useState<ScanOptions>({
+    flags: '',
+    reducedMotion: prefersReducedMotion,
+  });
+  const [currentStep, setCurrentStep] = useState(1);
+
+  const handleTargetChange = (index: number, value: string) => {
+    const updated = [...targets];
+    updated[index] = value;
+    setTargets(updated);
+  };
+
+  const addTarget = () => setTargets([...targets, '']);
+
+  const removeTarget = (index: number) => {
+    const updated = targets.filter((_, i) => i !== index);
+    setTargets(updated.length > 0 ? updated : ['']);
+  };
+
+  const handleStartScan = async () => {
     try {
-      console.log('Making API call to /api/scans...');
-      const response = await fetch('/api/scans', { method: 'POST' });
-      const data = await response.json();
-      console.log('Mock API Response:', data);
-      alert(`Success! Mock API returned scan ID: ${data.scan_id}`);
-    } catch (error) {
-      console.error('Error calling mock API:', error);
-      alert('Error calling mock API. Check the console.');
+      const response = await startScan({
+        targets: targets.filter((t) => t.trim() !== ''),
+        options,
+      });
+      if (response.status === 202) {
+        const id = response.data.scan_id;
+        navigate(`/dashboard?scan=${encodeURIComponent(id)}`);
+      } else {
+        console.error('Unexpected response', response);
+      }
+    } catch (err) {
+      console.error('Failed to start scan', err);
     }
   };
+
+  const renderTargetsStep = () => (
+    <div>
+      <h2>Targets</h2>
+      {targets.map((target, idx) => (
+        <div key={idx} style={{ marginBottom: '0.5rem' }}>
+          <input
+            type="text"
+            value={target}
+            placeholder="Host or CIDR"
+            onChange={(e) => handleTargetChange(idx, e.target.value)}
+          />
+          {targets.length > 1 && (
+            <button type="button" onClick={() => removeTarget(idx)}>
+              Remove
+            </button>
+          )}
+        </div>
+      ))}
+      <button type="button" onClick={addTarget}>
+        Add Target
+      </button>
+    </div>
+  );
+
+  const renderOptionsStep = () => (
+    <div>
+      <h2>Options</h2>
+      <div>
+        <label>
+          Nmap Flags:
+          <input
+            type="text"
+            value={options.flags}
+            onChange={(e) =>
+              setOptions({ ...options, flags: e.target.value })
+            }
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={options.reducedMotion}
+            onChange={(e) =>
+              setOptions({ ...options, reducedMotion: e.target.checked })
+            }
+          />
+          Reduced motion
+        </label>
+      </div>
+    </div>
+  );
+
+  const renderSummaryStep = () => (
+    <div>
+      <h2>Summary</h2>
+      <div>
+        <h3>Targets</h3>
+        <ul>
+          {targets
+            .filter((t) => t.trim() !== '')
+            .map((t, idx) => (
+              <li key={idx}>{t}</li>
+            ))}
+        </ul>
+      </div>
+      <div>
+        <h3>Options</h3>
+        <p>Nmap Flags: {options.flags || '(none)'}</p>
+        <p>
+          Reduced Motion: {options.reducedMotion ? 'Enabled' : 'Disabled'}
+        </p>
+      </div>
+      <button onClick={handleStartScan}>Start Scan</button>
+    </div>
+  );
 
   return (
     <div>
       <h1>New Scan</h1>
-      <p>This is the page where the new scan wizard will be built.</p>
-      <hr />
-      <button onClick={handleTestApiCall}>
-        Test Mock API Call (POST /api/scans)
-      </button>
+      {currentStep === 1 && renderTargetsStep()}
+      {currentStep === 2 && renderOptionsStep()}
+      {currentStep === 3 && renderSummaryStep()}
+      <div style={{ marginTop: '1rem' }}>
+        {currentStep > 1 && (
+          <button onClick={() => setCurrentStep(currentStep - 1)}>Back</button>
+        )}
+        {currentStep < 3 && (
+          <button
+            onClick={() => setCurrentStep(currentStep + 1)}
+            disabled={
+              currentStep === 1 &&
+              targets.every((t) => t.trim() === '')
+            }
+          >
+            Next
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/web_ui/client/src/services/api.ts
+++ b/web_ui/client/src/services/api.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+export interface ScanOptions {
+  flags: string;
+  reducedMotion: boolean;
+}
+
+export interface StartScanPayload {
+  targets: string[];
+  options: ScanOptions;
+}
+
+export interface StartScanResponse {
+  scan_id: string;
+}
+
+export async function startScan(payload: StartScanPayload) {
+  return axios.post<StartScanResponse>('/api/scans', payload);
+}


### PR DESCRIPTION
## Summary
- add multi-step wizard for configuring new scans with targets and options
- include reduced motion toggle honoring user preference
- call /api/scans and navigate to dashboard on acceptance

## Testing
- ⚠️ `npm test` (missing script)
- ✅ `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_689eaddd504483218670ad276e7f0122