### PR TITLE
fix: use package-relative imports

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -5,14 +5,12 @@ from datetime import datetime
 import asyncio
 import typer
 
-from sqlalchemy.orm import Session
-
-from db.session import init_engine, get_session, DEFAULT_DB_PATH
-from db import repository as db_repo
-from db.models import JobStatus
-import reporting
-from ip_handler import expand_targets
-from runner import run_jobs_concurrently
+from ..db.session import Session, init_engine, get_session, DEFAULT_DB_PATH
+from ..db import repository as db_repo
+from ..db.models import JobStatus
+from .. import reporting
+from ..ip_handler import expand_targets
+from ..runner import run_jobs_concurrently
 
 app = typer.Typer(help="NetScan Orchestrator CLI")
 

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -1,7 +1,7 @@
 """Database utilities for NetScanOrchestrator."""
 
-from db.session import get_session, init_engine
-from db.models import Base, Target, ScanRun, Batch, Job, Result, JobStatus
+from .session import get_session, init_engine
+from .models import Base, Target, ScanRun, Batch, Job, Result, JobStatus
 
 __all__ = [
     "get_session",

--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -6,7 +6,7 @@ from typing import Iterable, List, Optional, Type, TypeVar, Any
 
 from sqlalchemy.orm import Session
 
-from db.models import Target, ScanRun, Batch, Job, Result
+from .models import Target, ScanRun, Batch, Job, Result
 
 ModelType = TypeVar("ModelType", Target, ScanRun, Batch, Job, Result)
 

--- a/src/db/session.py
+++ b/src/db/session.py
@@ -8,7 +8,7 @@ from typing import Optional
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session, Session
 
-from db.models import Base
+from .models import Base
 
 DEFAULT_DB_PATH = os.path.join(".netscan_orchestrator", "state.db")
 

--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -1,4 +1,16 @@
-import nmap
+try:
+    import nmap
+except ModuleNotFoundError:  # pragma: no cover
+    class _PortScannerError(Exception):
+        pass
+
+    class _PortScanner:
+        PortScannerError = _PortScannerError
+
+        def __init__(self, *args, **kwargs):
+            raise self.PortScannerError("nmap program was not found")
+
+    nmap = type("nmap", (), {"PortScanner": _PortScanner, "PortScannerError": _PortScannerError})
 import logging
 from typing import List, Dict, Any # Added typing
 

--- a/src/reporting.py
+++ b/src/reporting.py
@@ -14,9 +14,8 @@ from typing import Any, Dict, List, Optional
 import csv
 import json
 
-from sqlalchemy.orm import Session
-
-from db.models import ScanRun, Batch, Job
+from .db.session import Session
+from .db.models import ScanRun, Batch, Job
 
 
 # ---------------------------------------------------------------------------

--- a/src/runner.py
+++ b/src/runner.py
@@ -3,10 +3,9 @@ from datetime import datetime
 from subprocess import PIPE
 from typing import List
 
-from sqlalchemy.orm import Session
-
-from db import repository as db_repo
-from db.models import Job, JobStatus
+from .db.session import Session
+from .db import repository as db_repo
+from .db.models import Job, JobStatus
 
 
 async def execute_job(job_id: int, db_session: Session, timeout_sec: int):

--- a/web_ui/app.py
+++ b/web_ui/app.py
@@ -1,6 +1,6 @@
 import os
 import json
-from flask import Flask, render_template, abort, url_for, request, redirect, flash # Added request, redirect, flash
+from flask import Flask, render_template, abort, url_for, request, redirect, flash, BadRequest
 import datetime # Added datetime
 from multiprocessing import cpu_count # Added cpu_count
 
@@ -142,7 +142,6 @@ def index():
     return render_template('index.html', files=available_scan_files, project_files=available_project_files)
 
 
-from werkzeug.exceptions import BadRequest # Import BadRequest
 
 @app.route('/save_host_config', methods=['POST'])
 def save_host_config():


### PR DESCRIPTION
## Summary
- use relative imports for internal modules
- handle missing BadRequest import
- guard nmap scanner against missing dependency

## Testing
- `pytest` *(fails: No module named 'sqlalchemy'; No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_b_689f080598908321b7c30424dd485977