### PR TITLE
Add Docker Compose setup for Flask web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,13 @@ Once installed, the `netscan` command will be available. The general workflow is
 5.  `netscan status`
 
 For a detailed walkthrough with examples, please see the [Usage Guide](docs/USAGE.md).
+
+### Docker Compose
+
+A `docker-compose.yml` file is provided to run the Flask web UI inside a container. To build the image and start the service, run:
+
+```bash
+docker compose up --build
+```
+
+The application will be accessible at http://localhost:5000 and will persist data to the local `data/` directory.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - "5000:5000"
+    volumes:
+      - "./data:/app/data"
+    environment:
+      FLASK_APP: web_ui.app
+      FLASK_ENV: development


### PR DESCRIPTION
## Summary
- add docker-compose configuration to build and run the Flask app
- document using `docker compose up --build` in the README

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'db')*

------
https://chatgpt.com/codex/tasks/task_b_689f62147d888321a45e19dc7a5e4a40