### PR TITLE
docs: recommend Gunicorn for production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,6 @@ EXPOSE 5000
 
 ENTRYPOINT ["tini", "--"]
 CMD ["python", "-m", "flask", "run", "--host=0.0.0.0", "--port=5000"]
+# Example production command using Gunicorn:
+# CMD ["gunicorn", "-b", "0.0.0.0:5000", "web_ui.app:app"]
 

--- a/README.md
+++ b/README.md
@@ -56,3 +56,13 @@ docker compose up --build
 ```
 
 The application will be accessible at http://localhost:5000 and will persist data to the local `data/` directory.
+
+### Production Deployment
+
+For production use, run the Flask web UI with Gunicorn instead of the built-in development server:
+
+```bash
+gunicorn -b 0.0.0.0:5000 web_ui.app:app
+```
+
+This binds Gunicorn to all interfaces on port 5000 and serves the `app` object from `web_ui/app.py`.


### PR DESCRIPTION
## Summary
- advise using Gunicorn to serve Flask in production
- add a commented example Gunicorn CMD in the Dockerfile

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'db')*


------
https://chatgpt.com/codex/tasks/task_b_689f6403662c83219e4683dd632022be