### PR TITLE
feat(tests): Add comprehensive API contract and WebSocket tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ SQLAlchemy>=1.4
 uvicorn[standard]
 fastapi
 python-multipart
+async-asgi-testclient
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -173,6 +173,7 @@ def run(
     # Run the jobs concurrently
     asyncio.run(
         run_jobs_concurrently(
+            scan_run_id=scan_run_id,
             job_ids=job_ids,
             db_session=session,
             concurrency=concurrency,

--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -135,6 +135,11 @@ def list_jobs(session: Session) -> List[Job]:
     return _list(session, Job)
 
 
+def list_jobs_for_scan_run(session: Session, scan_run_id: int) -> List[Job]:
+    """Return all Jobs for a given ScanRun."""
+    return session.query(Job).filter(Job.scan_run_id == scan_run_id).all()
+
+
 def update_job(session: Session, job_id: int, **kwargs: Any) -> Optional[Job]:
     return _update(session, Job, job_id, **kwargs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,44 @@
+import os
+import tempfile
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from web_api.app import app
+from web_api.deps import get_db
+from src.db.session import Base, init_engine as init_global_engine
+
+@pytest.fixture(scope="function")
+def test_db_session():
+    """
+    Pytest fixture to create a temporary, isolated database for a test function.
+    It overrides the FastAPI `get_db` dependency.
+    """
+    # Create a temporary file for the database
+    db_fd, db_path = tempfile.mkstemp(suffix=".db")
+
+    # Use a separate engine for the test DB
+    engine = create_engine(f"sqlite:///{db_path}")
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    # Create tables
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        """Dependency override to use the temporary database."""
+        try:
+            db = TestingSessionLocal()
+            yield db
+        finally:
+            db.close()
+
+    # Apply the override
+    app.dependency_overrides[get_db] = override_get_db
+
+    # Yield a session for the test to use if needed, though the override is the main point
+    yield TestingSessionLocal()
+
+    # Teardown: remove the override and close/delete the DB
+    app.dependency_overrides.clear()
+    os.close(db_fd)
+    os.unlink(db_path)

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -1,0 +1,118 @@
+import asyncio
+import os
+import sys
+import json
+from unittest.mock import patch, AsyncMock
+
+import pytest
+from async_asgi_testclient import TestClient as AsyncTestClient
+from starlette import status
+from starlette.websockets import WebSocketDisconnect
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from web_api.app import app
+from web_api.deps import get_db
+
+SAMPLE_TARGETS = ["127.0.0.1", "127.0.0.2", "127.0.0.3"]
+
+@pytest.fixture(scope="module")
+def anyio_backend():
+    return "asyncio"
+
+@pytest.mark.anyio
+@patch("web_api.app.scan_task_wrapper", new_callable=AsyncMock)
+async def test_websocket_flow_and_api_parity(mock_scan_wrapper, test_db_session):
+    test_finished_event = asyncio.Event()
+
+    async def mock_bg_task(scan_run_id, job_ids, update_queue):
+        db_gen = app.dependency_overrides[get_db]()
+        db = next(db_gen)
+        try:
+            from src.db.models import JobStatus
+            from src.db import repository as db_repo
+            for i, job_id in enumerate(job_ids):
+                target = SAMPLE_TARGETS[i]
+                db_repo.update_job(db, job_id=job_id, status=JobStatus.RUNNING)
+                await update_queue.put({"type": "CHUNK_UPDATE", "payload": {"chunk_id": str(job_id), "status": "RUNNING"}})
+                await asyncio.sleep(0.01)
+                status_val = JobStatus.COMPLETED if i % 2 == 0 else JobStatus.FAILED
+                db_repo.update_job(db, job_id=job_id, status=status_val, reason="test")
+                await update_queue.put({
+                    "type": "CHUNK_UPDATE",
+                    "payload": {"chunk_id": str(job_id), "status": status_val.name, "result": {"address": target, "status": "up" if status_val == JobStatus.COMPLETED else "down", "reason": "syn-ack"}},
+                })
+            db_repo.update_scan_run(db, scan_run_id, status=JobStatus.COMPLETED)
+            await update_queue.put({
+                "type": "SCAN_COMPLETE",
+                "payload": {"scan_id": str(scan_run_id), "status": "COMPLETED", "final_results_url": f"/api/scans/{scan_run_id}"},
+            })
+            await update_queue.put(None)
+        finally:
+            db.close()
+            await test_finished_event.wait()
+
+    mock_scan_wrapper.side_effect = mock_bg_task
+
+    async with AsyncTestClient(app) as client:
+        response = await client.post("/api/scans", json={"targets": SAMPLE_TARGETS, "nmap_options": "-sT"})
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        scan_id = response.json()["scan_id"]
+
+        received_messages = []
+        try:
+            async with client.websocket_connect(f"/ws/scans/{scan_id}") as websocket:
+                while True:
+                    data = await websocket.receive_text()
+                    received_messages.append(json.loads(data))
+        except Exception:
+            # This client library raises a generic Exception on disconnect.
+            pass
+        finally:
+            test_finished_event.set()
+
+        # Specific message count assertions
+        running_updates = [msg for msg in received_messages if msg.get("type") == "CHUNK_UPDATE" and msg.get("payload", {}).get("status") == "RUNNING"]
+        final_updates = [msg for msg in received_messages if msg.get("type") == "CHUNK_UPDATE" and msg.get("payload", {}).get("status") in ["COMPLETED", "FAILED"]]
+        scan_complete_messages = [msg for msg in received_messages if msg["type"] == "SCAN_COMPLETE"]
+
+        assert len(running_updates) == len(SAMPLE_TARGETS)
+        assert len(final_updates) == len(SAMPLE_TARGETS)
+        assert len(scan_complete_messages) == 1
+
+        # Assert that SCAN_COMPLETE is the last message
+        assert received_messages[-1]["type"] == "SCAN_COMPLETE"
+
+        response = await client.get(f"/api/scans/{scan_id}")
+        api_data = response.json()["data"]
+        assert api_data["progress"]["completed_chunks"] == 2
+
+@pytest.mark.anyio
+async def test_websocket_rejects_nonexistent_scan(test_db_session):
+    async with AsyncTestClient(app) as client:
+        with pytest.raises(Exception) as excinfo:
+            async with client.websocket_connect("/ws/scans/999999") as websocket:
+                await websocket.receive_text()
+        # The library raises a generic exception, but we can inspect the message inside it
+        # It should contain the ASGI close event details
+        assert excinfo.value.args[0]["type"] == "websocket.close"
+        assert excinfo.value.args[0]["code"] == status.WS_1008_POLICY_VIOLATION
+
+
+@pytest.mark.anyio
+@patch("web_api.app.scan_manager.get_scan_queue", return_value=None)
+async def test_websocket_rejects_completed_scan(mock_get_queue, test_db_session):
+    async with AsyncTestClient(app) as client:
+        with pytest.raises(Exception) as excinfo:
+            async with client.websocket_connect("/ws/scans/1") as websocket:
+                await websocket.receive_text()
+        assert excinfo.value.args[0]["type"] == "websocket.close"
+        assert excinfo.value.args[0]["code"] == status.WS_1008_POLICY_VIOLATION
+
+@pytest.mark.anyio
+async def test_cors_preflight_request(test_db_session):
+    headers = {"Origin": "http://localhost:5173", "Access-Control-Request-Method": "POST", "Access-Control-Request-Headers": "Content-Type"}
+    async with AsyncTestClient(app) as client:
+        response = await client.options("/api/scans", headers=headers)
+        assert response.status_code == 200
+        assert response.headers["access-control-allow-origin"] == "http://localhost:5173"

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,69 +1,59 @@
 import os
+import sys
 import tempfile
-import unittest
 from datetime import datetime, timedelta
 
-from src.db.session import init_engine, get_session
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 from src.db import repository as db_repo
 from src import reporting
 
+def test_summary_queries_and_exports(test_db_session):
+    """
+    Tests reporting queries and export functions using an isolated DB session.
+    """
+    session = test_db_session
+    run = db_repo.create_scan_run(session, status="completed")
+    t1 = db_repo.create_target(session, address="1.1.1.1")
+    t2 = db_repo.create_target(session, address="2.2.2.2")
+    start = datetime.utcnow()
+    db_repo.create_job(
+        session,
+        scan_run_id=run.id,
+        target_id=t1.id,
+        status="completed",
+        started_at=start,
+        completed_at=start + timedelta(seconds=5),
+    )
+    j2 = db_repo.create_job(
+        session,
+        scan_run_id=run.id,
+        target_id=t2.id,
+        status="failed",
+        started_at=start,
+        completed_at=start + timedelta(seconds=10),
+    )
+    db_repo.create_result(session, job_id=j2.id, stderr="timeout")
 
-class TestReportingModule(unittest.TestCase):
-    def setUp(self):
-        tmp = tempfile.NamedTemporaryFile(delete=False)
-        tmp.close()
-        self.db_path = tmp.name
-        init_engine(self.db_path)
-        self.session = get_session()
+    runs = reporting.summarise_runs(session)
+    assert runs[0]["failed_jobs"] == 1
 
-    def tearDown(self):
-        self.session.close()
-        if os.path.exists(self.db_path):
-            os.unlink(self.db_path)
+    slowest = reporting.get_slowest_jobs(session)
+    assert slowest[0]["job_id"] == j2.id
 
-    def test_summary_queries_and_exports(self):
-        run = db_repo.create_scan_run(self.session, status="completed")
-        t1 = db_repo.create_target(self.session, address="1.1.1.1")
-        t2 = db_repo.create_target(self.session, address="2.2.2.2")
-        start = datetime.utcnow()
-        db_repo.create_job(
-            self.session,
-            scan_run_id=run.id,
-            target_id=t1.id,
-            status="completed",
-            started_at=start,
-            completed_at=start + timedelta(seconds=5),
-        )
-        j2 = db_repo.create_job(
-            self.session,
-            scan_run_id=run.id,
-            target_id=t2.id,
-            status="failed",
-            started_at=start,
-            completed_at=start + timedelta(seconds=10),
-        )
-        db_repo.create_result(self.session, job_id=j2.id, stderr="timeout")
+    failed = reporting.get_failed_jobs(session)
+    assert failed[0]["error"] == "timeout"
 
-        runs = reporting.summarise_runs(self.session)
-        self.assertEqual(runs[0]["failed_jobs"], 1)
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".json") as tmp_json, \
+         tempfile.NamedTemporaryFile(delete=False, suffix=".csv") as tmp_csv:
 
-        slowest = reporting.get_slowest_jobs(self.session)
-        self.assertEqual(slowest[0]["job_id"], j2.id)
-
-        failed = reporting.get_failed_jobs(self.session)
-        self.assertEqual(failed[0]["error"], "timeout")
-
-        tmp_json = tempfile.NamedTemporaryFile(delete=False)
-        tmp_json.close()
-        tmp_csv = tempfile.NamedTemporaryFile(delete=False)
-        tmp_csv.close()
         reporting.export_json(runs, tmp_json.name)
         reporting.export_csv(runs, tmp_csv.name)
-        self.assertTrue(os.path.getsize(tmp_json.name) > 0)
-        self.assertTrue(os.path.getsize(tmp_csv.name) > 0)
-        os.unlink(tmp_json.name)
-        os.unlink(tmp_csv.name)
 
+        assert os.path.getsize(tmp_json.name) > 0
+        assert os.path.getsize(tmp_csv.name) > 0
 
-if __name__ == "__main__":
-    unittest.main()
+    os.unlink(tmp_json.name)
+    os.unlink(tmp_csv.name)

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -9,15 +9,15 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from unittest.mock import patch, MagicMock
 from web_api.app import app
 
-client = TestClient(app)
-
 def test_health_check():
+    client = TestClient(app)
     response = client.get("/healthz")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
 
 @patch("web_api.app.asyncio.create_task")
-def test_start_scan(mock_create_task):
+def test_start_scan(mock_create_task, test_db_session):
+    client = TestClient(app)
     response = client.post(
         "/api/scans",
         json={"targets": ["127.0.0.1"], "nmap_options": "-sT"},
@@ -27,7 +27,8 @@ def test_start_scan(mock_create_task):
     mock_create_task.assert_called_once()
 
 @patch("web_api.app.db_repo")
-def test_get_scan_status(mock_db_repo):
+def test_get_scan_status(mock_db_repo, test_db_session):
+    client = TestClient(app)
     # Mock the return values of the database functions
     mock_scan_run = MagicMock()
     mock_scan_run.status.name = "COMPLETED"


### PR DESCRIPTION
This commit introduces a new test suite to validate the system's external communication, ensuring that the REST and WebSocket APIs adhere to the defined contract.

Key changes:
- Adds `tests/test_api_contract.py` with tests for WebSocket message flows (`CHUNK_UPDATE`, `SCAN_COMPLETE`), REST API parity, CORS headers, and error handling.
- Implements these tests using `async-asgi-testclient` to handle asynchronous testing of the FastAPI application, including background tasks.
- Introduces a `pytest` fixture in `tests/conftest.py` to provide isolated, temporary databases for each test function, preventing state leakage between tests.
- Modernizes the existing `tests/test_reporting.py` from a `unittest.TestCase` to a `pytest` function utilizing the new database fixture.
- Updates `tests/test_web_api.py` to use the database fixture for improved isolation.
- Fixes a bug in `src/cli/main.py` where `scan_run_id` was not being passed to the runner.
- Fixes a bug in `web_api/app.py` by adding the missing `list_jobs_for_scan_run` function to the database repository.